### PR TITLE
add styling for types and expandable admonitions

### DIFF
--- a/material-overrides/assets/stylesheets/polkadot.css
+++ b/material-overrides/assets/stylesheets/polkadot.css
@@ -491,6 +491,49 @@ li > nav.md-nav[data-md-level='4'] ul.md-nav__list {
   mask-image: XXX;
 }
 
+/* Styling for function description admonition */
+.md-typeset details.function {
+  border: none;
+  margin: 0.1rem;
+}
+
+.md-typeset .function > summary {
+  background-color: unset;
+}
+
+.md-typeset .function > summary::before {
+  display: none;
+}
+
+.md-typeset .function > summary::after {
+  left: 0.6rem;
+}
+
+.md-typeset .function summary {
+  font-weight: 400;
+  font-size: 0.8rem;
+}
+
+html .md-typeset details.function div.tabbed-set,
+.md-typeset .function p,
+.md-typeset .function .admonition {
+  margin: 1em 2em;
+}
+
+.md-typeset .function .admonition * {
+  margin: 0 -0.6rem;
+  padding-top: 0.4rem;
+}
+
+.md-typeset .function .admonition > p:not(:first-child) {
+  padding-left: 0.6rem;
+  padding-right: 0.6rem;
+}
+
+.md-typeset .function summary code {
+  box-shadow: none;
+}
+
 /* Styling for the Copy to Clipboard */
 /* Clipboard icon */
 .md-clipboard {


### PR DESCRIPTION
This adds styling for the expandable admonitions and the parameter types, as seen here:
![Screenshot 2024-07-25 at 8 01 20 AM](https://github.com/user-attachments/assets/f212d25c-81ad-4618-bae0-cb47cd43798f)

